### PR TITLE
Adjust default on condition in order to display records in Table Drawer sample page

### DIFF
--- a/Skuid_Techniques/Drawers_Related_Records/AccountChildrenTableDrawers.xml
+++ b/Skuid_Techniques/Drawers_Related_Records/AccountChildrenTableDrawers.xml
@@ -15,7 +15,7 @@
 				<field id="Description"/>
 			</fields>
 			<conditions>
-				<condition type="fieldvalue" value="Hatch" enclosevalueinquotes="true" field="Owner.LastName" fieldtargetobjects="User" clientorserver="server"/>
+				<condition type="fieldvalue" enclosevalueinquotes="true" field="Owner.LastName" fieldtargetobjects="User" clientorserver="server" state="filterableoff" inactive="true" name="Owner.LastName"/>
 			</conditions>
 			<actions/>
 		</model>

--- a/Skuid_Techniques/Drawers_Related_Records/README.md
+++ b/Skuid_Techniques/Drawers_Related_Records/README.md
@@ -15,7 +15,7 @@ This page shows an account list, with a drawer that provides additional detail a
 
 ## Notes
 Here are the key areas to be reviewed. 
--  Model properties: The contact model has a filterable condition,  and does not load data on page load. 
+-  Model properties: The contact model has a filterable condition. 
 -  Table display properties: Drawers are enabled
 -  Drawer icon:  Click icon on left of table to expose Drawer Properties. 
 -  Before Load Actions: This sequence of actions only runs the first time the drawer is opened.  You don't need to query for ACME's contacts on the second time ACME's drawer is opened.  


### PR DESCRIPTION
This sample page currently has a hardcoded, always-on condition. This change removes that condition value and sets it to off by default so the page can display records as soon as it's placed in the page.

I imagine the condition is there currently to make sure users reach the Readme... But this works fine without much context right? Lemme know if I'm offbase.