### PR TITLE
Easier download links

### DIFF
--- a/Design_Systems/Compact_Data_Workspace/README.md
+++ b/Design_Systems/Compact_Data_Workspace/README.md
@@ -31,8 +31,8 @@ The Compact Data Workspace design system is compact, practical, with plenty of v
 
 ## Usage
 - API: v2
-- Design System: Download [Compact Data Workspace Design System](CompactDataWorkspace.designsystem) and import it to Skuid's Design Systems.
-- Demo page: Download the [Demo Page](CompactDataWorkspace_DemoPage.xml). In Skuid, create a new page and select Import XML file to import this demo page.
+- Design System: Download [Compact Data Workspace Design System](CompactDataWorkspace.designsystem?raw=true) and import it to Skuid's Design Systems.
+- Demo page: Download the [Demo Page](CompactDataWorkspace_DemoPage.xml?raw=true). In Skuid, create a new page and select Import XML file to import this demo page.
 
 ## Notes
 - For usage in Salesforce, this design system works for version [Spark Update 3](https://docs.skuid.com/v12.4.2/v2/en/release-notes.html) or higher. Older versions of Skuid can result in styling losses.

--- a/Design_Systems/Material/README.md
+++ b/Design_Systems/Material/README.md
@@ -26,8 +26,8 @@ A Skuid design system for web apps that follow [Material design guidelines](http
 
 ## Usage
 - API: v2
-- Design System: Download [Material Design System](Material.designsystem) and import it to Skuid's Design Systems.
-- Demo page: Download the [Demo Page](Material_DesignSystem_DemoPage.xml). In Skuid, create a new page and select Import XML file to import this demo page.
+- Design System: Download [Material Design System](Material.designsystem?raw=true) and import it to Skuid's Design Systems.
+- Demo page: Download the [Demo Page](Material_DesignSystem_DemoPage.xml?raw=true). In Skuid, create a new page and select Import XML file to import this demo page.
 
 ## Notes
 - For usage in Salesforce, this design system works for version [Spark Update 3](https://docs.skuid.com/v12.4.2/v2/en/release-notes.html) or higher. Older versions of Skuid can result in styling losses.

--- a/Design_Systems/SimpleCRM/README.md
+++ b/Design_Systems/SimpleCRM/README.md
@@ -25,8 +25,8 @@ A design system customized to provide a consistent CRM user interface.
 
 ## Usage
 - API: v2
-- Design System: Download [Simple CRM Design System](SimpleCRM.designsystem) and import it to Skuid's Design Systems.
-- Demo page: Download the [Demo Page](SimpleCRM_DesignSystem_DemoPage.xml). In Skuid, create a new page and select Import XML file to import this demo page.
+- Design System: Download [Simple CRM Design System](SimpleCRM.designsystem?raw=true) and import it to Skuid's Design Systems.
+- Demo page: Download the [Demo Page](SimpleCRM_DesignSystem_DemoPage.xml?raw=true). In Skuid, create a new page and select Import XML file to import this demo page.
 
 ## Notes
 - For usage in Salesforce, this design system works for version [Spark Update 3](https://docs.skuid.com/v12.4.2/v2/en/release-notes.html) or higher. Older versions of Skuid can result in styling losses.

--- a/Releases/Boston/README.md
+++ b/Releases/Boston/README.md
@@ -12,5 +12,5 @@ Link to [Skuid Boston's release notes](https://docs.skuid.com/v13.0.4/en/release
 Once you have Skuid Boston installed in your sandbox or dev org, you can import the demo page XML and the design system linked below.
 
 - API: v2
-- Design System: Download the [BostonDemo design system](BostonDemo.designsystem). In Skuid, go to Design Systems and import the downloaded design system.
-- Demo page: Download the [demo page](BostonDemo.xml). In Skuid, create a new page and select Import XML file to import this demo page.
+- Design System: Download the [BostonDemo design system](BostonDemo.designsystem?raw=true). In Skuid, go to Design Systems and import the downloaded design system.
+- Demo page: Download the [demo page](BostonDemo.xml?raw=true). In Skuid, create a new page and select Import XML file to import this demo page.

--- a/Salesforce_Advanced/APEX_Rest/README.md
+++ b/Salesforce_Advanced/APEX_Rest/README.md
@@ -6,7 +6,7 @@ This page is an example supporting this article in [Skuid Docs](https://docs.sku
 - Page API:  V1
 - Data source: Uses ApexREST datasource and Salesforce Authenication Provider.   See Doc link above for details.   
 - Design system: None 
-- Page XML:  [Copy the XML from this page](ApexREST.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](ApexREST.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links: 

--- a/Salesforce_Advanced/Approval_Process_Actions/README.md
+++ b/Salesforce_Advanced/Approval_Process_Actions/README.md
@@ -10,7 +10,7 @@ This sample page shows both of these in action. A set of interrelated models is 
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](ApprovalProcessActions.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](ApprovalProcessActions.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 - Before this page can run - an approval process must be created on the Case object. 

--- a/Salesforce_Advanced/Content_Document/README.md
+++ b/Salesforce_Advanced/Content_Document/README.md
@@ -14,7 +14,7 @@ In each case functionality is provided to preview, download, edit metadata and r
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](ContentDocumentExamples.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](ContentDocumentExamples.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links

--- a/Salesforce_Advanced/Create_Record_and_File/README.md
+++ b/Salesforce_Advanced/Create_Record_and_File/README.md
@@ -23,7 +23,7 @@ We also include some JavaScript and an action sequence that deletes the uploaded
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](CreateRecordAndFile.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](CreateRecordAndFile.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links

--- a/Salesforce_Advanced/Custom_Home_Page/README.md
+++ b/Salesforce_Advanced/Custom_Home_Page/README.md
@@ -6,7 +6,7 @@ This page is an example supporting this article in [Skuid Docs](https://docs.sku
 - Page API:  V1
 - Data source: Uses default Salesforce data source.
 - Design system: None 
-- Page XML:  [Copy the XML from this page](CustomHomePage.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](CustomHomePage.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links 

--- a/Salesforce_Advanced/Duplicate_Management/README.md
+++ b/Salesforce_Advanced/Duplicate_Management/README.md
@@ -17,7 +17,7 @@ This example leverages the standard duplicate rule "Standard Rule for Leads with
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](DuplicateLeadWarning.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](DuplicateLeadWarning.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 To see this page in action,  find a lead that matches a contact's name and email address.  Then Preview the page using that lead.
 

--- a/Salesforce_Advanced/Follow_or_Unfollow_Records/README.md
+++ b/Salesforce_Advanced/Follow_or_Unfollow_Records/README.md
@@ -10,7 +10,7 @@ Skuid pages can be configured to include this process.  The example below shows 
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](FollowRecords.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](FollowRecords.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 - Chatter must be turned on in the org for this to function correctly. 

--- a/Salesforce_Advanced/Merging_Duplicate_Records/README.md
+++ b/Salesforce_Advanced/Merging_Duplicate_Records/README.md
@@ -17,7 +17,7 @@ This example is described in more detail in a [blog post at Skuid Word](https://
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](LeadDedupe.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](LeadDedupe.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links

--- a/Salesforce_Advanced/Recurring_Tasks/README.md
+++ b/Salesforce_Advanced/Recurring_Tasks/README.md
@@ -75,7 +75,7 @@ See sample page that shows this working.
 - Page API: V2
 - Data source: Uses default Salesforce data source. (Note that Activity Recurrence must be turned on in the org) 
 - Design system: None
-- Page XML:  [Copy the XML from this page](CreateRecurringTask.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.
+- Page XML:  [Copy the XML from this page](CreateRecurringTask.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.
 
 #### Overview
 There are four core concepts driving this page you will want to explore. 
@@ -146,7 +146,7 @@ A second page provides an initial example for managing existing tasks. This incl
 - Page API: V2
 - Data source: Uses default Salesforce data source. (Note that Activity Recurrence must be turned on in the org) 
 - Design system: None
-- Page XML: [Copy the XML from this page](TaskListWithRecurrence.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.
+- Page XML: [Copy the XML from this page](TaskListWithRecurrence.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.
 
 #### Notes about the page: 
 

--- a/Salesforce_Advanced/Work_Dot_Com_Command_Center/README.md
+++ b/Salesforce_Advanced/Work_Dot_Com_Command_Center/README.md
@@ -81,7 +81,7 @@ Finally - because it's Skuid, it can be beautiful. We used one of the [sample de
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Design_Systems/Material/Material.designsystem), and use the Import function on the Design System page to add this system to your org.
     - You might also want to look at the [demo page](https://github.com/skuid/SamplePages/blob/master/Design_Systems/Material/Material_DesignSystem_DemoPage.xml) for that design system. 
 
-- Page XML:  [Copy the XML from this page](WellnessForm.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](WellnessForm.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
     - IMPORTANT!  Before running this page you will need to find the `Consent` model,  open the Conditions,  look for `AuthorizationFormTextId` and replace the `ID` in its value with the one you copied in step 2 (Configure Consent Management) above. 
 
 When you preview this page - it will ask you to select an `Individual`.  Make sure an Individual you select is connected to an `Employee`.   The Work.com install script should do this - but we've seen situations where it does not work.   

--- a/Skuid_Techniques/Action_Fwk_Examples/README.MD
+++ b/Skuid_Techniques/Action_Fwk_Examples/README.MD
@@ -10,7 +10,7 @@ This page shows a number of examples of the way Actions are used in typical Skui
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](Opportunity_Detail_Action_Showcase.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Opportunity_Detail_Action_Showcase.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 

--- a/Skuid_Techniques/Drawers_Related_Records/README.md
+++ b/Skuid_Techniques/Drawers_Related_Records/README.md
@@ -11,7 +11,7 @@ This page shows an account list, with a drawer that provides additional detail a
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](AccountChildrenTableDrawers.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](AccountChildrenTableDrawers.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 Here are the key areas to be reviewed. 

--- a/Skuid_Techniques/Filters_Using_Forms/README.md
+++ b/Skuid_Techniques/Filters_Using_Forms/README.md
@@ -8,7 +8,7 @@ While standard Skuid filters provide powerful functionality - there are times wh
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](Arbitrary_Filters.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Arbitrary_Filters.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 - Look at the actions in the "Filters" model. When changes are detected in those fields - the value is passed into a condition on the "Opportunities" model. 

--- a/Skuid_Techniques/KeyIndicators/README.MD
+++ b/Skuid_Techniques/KeyIndicators/README.MD
@@ -8,7 +8,7 @@ The combination of dynamic data access and dynamic UI components makes Skuid a g
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](KeyIndicators.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](KeyIndicators.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 Key disciplines for building a KPI block: 

--- a/Skuid_Techniques/Multi_Part_Form/README.md
+++ b/Skuid_Techniques/Multi_Part_Form/README.md
@@ -13,8 +13,8 @@ The example also shows how to include dynamic information within a navigation it
 ## Instructions
 - Page API:  V2
 - Data source: Only UI-only models are used. 
-- Design system: [Download this Design System file](SamplePages.designsystem).  Use the Import function on the Design System page to add this system to your org.  
-- Page XML:  [Copy the XML from this page](Multi_Part_Form.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Design system: [Download this Design System file](SamplePages.designsystem?raw=true).  Use the Import function on the Design System page to add this system to your org.  
+- Page XML:  [Copy the XML from this page](Multi_Part_Form.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 

--- a/Skuid_Techniques/Navigation/README.MD
+++ b/Skuid_Techniques/Navigation/README.MD
@@ -81,13 +81,13 @@ You will need to ensure the Design System used has Selected State defined so it 
 - Page API:  V2
 - Data source: None
 - Design system: See Note 
-- Page XML:  [Copy the XML from this page](Veritcal_Nav.xml), or save it as an XML file, and upload it as a new page.  
+- Page XML:  [Copy the XML from this page](Veritcal_Nav.xml?raw=true), or save it as an XML file, and upload it as a new page.  
 
 ### Integration of wizard and vertical navigation 
 - Page API:  V2
 - Data source: None
 - Design system: None 
-- Page XML:  [Copy the XML from this page](Wizard_Nav_Integration.xml), or save it as an XML file, and upload it as a new page.  
+- Page XML:  [Copy the XML from this page](Wizard_Nav_Integration.xml?raw=true), or save it as an XML file, and upload it as a new page.  
 
 
 

--- a/Skuid_Techniques/ReferenceSelection/README.md
+++ b/Skuid_Techniques/ReferenceSelection/README.md
@@ -12,7 +12,7 @@ In the example below - when creating a new task, account selection opens a popup
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: None 
-- Page XML:  [Copy the XML from this page](ReferenceSelectionPopup.xml), or save it as an XML file, and upload it as a new page.  
+- Page XML:  [Copy the XML from this page](ReferenceSelectionPopup.xml?raw=true), or save it as an XML file, and upload it as a new page.  
 
 ## Notes
 Here are the key areas to be reviewed. 

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -29,11 +29,11 @@ Current Skuid Release.  (This page may not work for Skuid Versions before 13.0)
    - Page API:  V2
    - Data source: Uses default Salesforce data source
    - Design System: Default 
-   - Page XML:  [Copy the XML from this page](SubscriptionManagement.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+   - Page XML:  [Copy the XML from this page](SubscriptionManagement.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 Prior Releases
    - Page API:  V1
-   - Page XML:  [Copy the XML from this page](LicenseManagement.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+   - Page XML:  [Copy the XML from this page](LicenseManagement.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 Related Links:  
@@ -50,7 +50,7 @@ Instructions:
    - Page API:  V2
    - Data source: Uses default Salesforce data source
    - Design System: Default 
-   - Page XML:  [Copy the XML from this page](SubscriptionAnalysis.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+   - Page XML:  [Copy the XML from this page](SubscriptionAnalysis.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
  ### <a href="SkuidLicenseUse_V2.xml" download="SkuidLicenseUse_V2.xml">Skuid User Logins - Last Six Months</a>  
@@ -63,14 +63,14 @@ Current Skuid Release.  (This page may not work for Skuid Versions before 13.0)
    - Page API:  V2
    - Data source: Uses default Salesforce data source
    - Design System: Default 
-   - Page XML:  [Copy the XML from this page](SkuidLicenseUse_V2.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+   - Page XML:  [Copy the XML from this page](SkuidLicenseUse_V2.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 Prior Releases
    - Page API:  V1   
    - Data source: Uses default Salesforce data source
    - Design System: None 
-   - Page XML:  [Copy the XML from this page](SiteLicenses_6months.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+   - Page XML:  [Copy the XML from this page](SiteLicenses_6months.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 Related Links:  
    - [Internal link in Demo Org](https://skuid-demo--skuid.na37.visual.force.com/apex/skuid__ui?page=SkuidLicenseUse_V2) (for Skuid Employees only)
@@ -88,13 +88,13 @@ Current Skuid Release.  (This page may not work for Skuid Versions before 13.0)
    - Page API:  V2
    - Data source: Uses default Salesforce data source
    - Design System: Default 
-   - Page XML:  [Copy the XML from this page](SkuidLicenseUse__1Month_V2.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org. 
+   - Page XML:  [Copy the XML from this page](SkuidLicenseUse__1Month_V2.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org. 
 
 Prior Releases
    - Page API:  V1  
    - Data source: Uses default Salesforce data source
    - Design System: None 
-   - Page XML:  [Copy the XML from this page](SiteLicenses_1Month.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+   - Page XML:  [Copy the XML from this page](SiteLicenses_1Month.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 Related Links:  
    - [Internal link in Demo Org](https://skuid-demo--skuid.na37.visual.force.com/apex/skuid__ui?page=SkuidLicenseUse__1Month_V2) (for Skuid Employees only)

--- a/Use_Cases/Account_Hierarchy/README.md
+++ b/Use_Cases/Account_Hierarchy/README.md
@@ -10,8 +10,8 @@ The list of Accounts on the left is filtered to only display Global/Parent accou
 ## Instructions
 - Page API:  V2
 - Data source: Uses default Salesforce data source
-- Design system: [Download this Design System file](AccountHierarchy.designsystem).  Use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Account_Hierarchy.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Design system: [Download this Design System file](AccountHierarchy.designsystem?raw=true).  Use the Import function on the Design System page to add this system to your org. 
+- Page XML:  [Copy the XML from this page](Account_Hierarchy.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Notes
@@ -26,23 +26,23 @@ The list of Accounts on the left is filtered to only display Global/Parent accou
 We did six webinars walking through the build for this use case.  Each chapter documents a different aspect of building the Skuid solution.  
 
 - [Chapter 1 | Understanding the Data Model](https://www.youtube.com/watch?v=s-99jr-zeFI)
-    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter1.xml)
-    - Additional page to help quickly create sample data:  [Quick Create Page](WebinarSeries_QuickCreatePage.xml)
+    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter1.xml?raw=true)
+    - Additional page to help quickly create sample data:  [Quick Create Page](WebinarSeries_QuickCreatePage.xml?raw=true)
 
 - [Chapter 2 | Page Construction - Layout and Account Interactions](https://www.youtube.com/watch?v=7RqtbD7Hybs)
-    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter2.xml)
+    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter2.xml?raw=true)
 
 - [Chapter 3 | Opportunities Chart and Tables](https://www.youtube.com/watch?v=CSk5DR54s5E)
-    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter3.xml)
+    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter3.xml?raw=true)
 
 - [Chapter 4 | Creating Variants in the Design System Studio](https://www.youtube.com/watch?v=rBZZhlmnFo0)
-    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries-Chapter4.xml)
+    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries-Chapter4.xml?raw=true)
 
 - [Chapter 5 | Design System Studio Style Variants Continued](https://www.youtube.com/watch?v=sYOMx_b0U2c)
-    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter5.xml)
+    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter5.xml?raw=true)
 
 - [Chapter 6 | Deploying App to Lightning](https://www.youtube.com/watch?v=2DuwP8D2_8U&t=2s)
-    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter6.xml)
+    - Page XML for this Chapter:  [Copy the XML from this page](WebinarSeries_Chapter6.xml?raw=true)
 
 
 ## Related Links

--- a/Use_Cases/Complex_Form/README.md
+++ b/Use_Cases/Complex_Form/README.md
@@ -9,7 +9,7 @@ The Mortgage Loan Application guides users applying for a mortgage with an intui
 - Page API:  V2
 - Data source: Uses default Salesforce data source
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Complex_Form.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Complex_Form.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 This page shows well several Skuid Capabilities. 

--- a/Use_Cases/Dashboard/README.md
+++ b/Use_Cases/Dashboard/README.md
@@ -8,7 +8,7 @@ A quick overview of key statistics and immediate calls to action.  Personalize t
 - Page API:  V2
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Dashboard.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Dashboard.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links

--- a/Use_Cases/Directory/README.md
+++ b/Use_Cases/Directory/README.md
@@ -8,7 +8,7 @@ A highly scannable view of records in individual cards. Usually contacts or lead
 - V2 Page API Used
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Directory.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Directory.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links

--- a/Use_Cases/Master_Detail/README.md
+++ b/Use_Cases/Master_Detail/README.md
@@ -8,7 +8,7 @@ Quickly work though multiple records, reviewing data and making updates without 
 - V2 Page API Used
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Master_Detail.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Master_Detail.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Related Links
 - [View page in App Gallery](https://portal.skuidsite.com/designsystem/samplepages/preview/contactdetail)

--- a/Use_Cases/Mobile_List/README.md
+++ b/Use_Cases/Mobile_List/README.md
@@ -8,7 +8,7 @@ You need a list of records on a phone - or other small form factor.
 - Page API:  V2
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Mobile_list_page.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Mobile_list_page.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes
 When previewing this page,  for best results use your browser's developer tools to emulate a phone or tablet form factor. 

--- a/Use_Cases/Opportunity_List/README.md
+++ b/Use_Cases/Opportunity_List/README.md
@@ -15,9 +15,9 @@ With this page you can do any of the following:
 
 - Data source: Uses default Salesforce data source
 
-- Design system: [Download this Design System file](CompactOpportunityMgt.designsystem). Use the Import function on the Design System page to add this design system to your org.
+- Design system: [Download this Design System file](CompactOpportunityMgt.designsystem?raw=true). Use the Import function on the Design System page to add this design system to your org.
 
-- Page XML: [Copy the XML from this page](Opportunity_List.xml), or save it as an XML file, and upload it as a new page in your Salesforce org.
+- Page XML: [Copy the XML from this page](Opportunity_List.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce org.
 
 ## Notes
 - Add filters through the Show Filters action, then hide them for more screen real estate while continuing to see the active filters on the table.

--- a/Use_Cases/Product_Selection/README.md
+++ b/Use_Cases/Product_Selection/README.md
@@ -8,7 +8,7 @@ Present a product catalog with robust filter and search capabilities. Let users 
 - Page API:  V2
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Product_Selection.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Product_Selection.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 
 ## Related Links

--- a/Use_Cases/Related_Lists/README.md
+++ b/Use_Cases/Related_Lists/README.md
@@ -10,8 +10,8 @@ The Lightning Account detail page is extended by using Skuid to display related 
 ## Instructions
 - Page API:  V2
 - Data source: Uses default Salesforce data source
-- Design system: [Download this Design System file](Skuid_Appetizer.designsystem).  Use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](FilteredLists.xml), or save it as an XML file, and upload it as a new page in your Salesforce org.  
+- Design system: [Download this Design System file](Skuid_Appetizer.designsystem?raw=true).  Use the Import function on the Design System page to add this system to your org. 
+- Page XML:  [Copy the XML from this page](FilteredLists.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce org.  
 - You can preview this page by itself to see the Skuid functionality,  but to see it on the Lightning Detail page you will have to add the Skuid Page component to a Lightning Page  and refer to this page there. 
 
 ## Notes

--- a/Use_Cases/Service_Request/README.md
+++ b/Use_Cases/Service_Request/README.md
@@ -15,8 +15,8 @@ However, With Skuid you can make a very simple looking form, that creates record
         - `Additional_Contact__c`:   A lookup to contact. 
         - `Service_Requested_For__c`: A date field. 
 
-- Design system: [Download this Design System file](CrispinConstruction.designsystem).  Use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Service_Request.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Design system: [Download this Design System file](CrispinConstruction.designsystem?raw=true).  Use the Import function on the Design System page to add this system to your org. 
+- Page XML:  [Copy the XML from this page](Service_Request.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Notes:
 

--- a/Use_Cases/Simple_List/README.md
+++ b/Use_Cases/Simple_List/README.md
@@ -8,7 +8,7 @@ Very scannable tables, displaying a robust amount of data with stacked columns.
 - Page API:  V2
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Simple_List.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Simple_List.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Related Links
 - [View page in App Gallery](https://portal.skuidsite.com/designsystem/samplepages/preview/simplelist)

--- a/Use_Cases/Task_List/README.md
+++ b/Use_Cases/Task_List/README.md
@@ -8,7 +8,7 @@ We all need a better to-do list. A Skuid list provide the tools to make just wha
 - Page API:  V2
 - Data source: Uses default Salesforce data source.   
 - Design system: [Download this Design System file](https://github.com/skuid/SamplePages/blob/master/Use_Cases/SamplePages.designsystem), and use the Import function on the Design System page to add this system to your org. 
-- Page XML:  [Copy the XML from this page](Task_List.xml), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
+- Page XML:  [Copy the XML from this page](Task_List.xml?raw=true), or save it as an XML file, and upload it as a new page in your Salesforce Org.  
 
 ## Related Links
 - [View page in App Gallery](https://portal.skuidsite.com/designsystem/samplepages/preview/todolist)


### PR DESCRIPTION
This PR adds the `raw=true` URL param to redirect for easier downloads. With this parameter, Github automatically redirects to the raw file, which allows users to instantly download. 

By doing this, we can keep relative URLs instead of going in and manually setting it to the raw URL. Which isn't how I started this project or anything (It definitely was).

Let me know if I missed any files! I only ran this find/replace for designsystem and XML files.