### PR TITLE
fix background datasource for Carousel pages

### DIFF
--- a/Skuid_Techniques/Carousel_Examples/Carousel.xml
+++ b/Skuid_Techniques/Carousel_Examples/Carousel.xml
@@ -47,7 +47,7 @@
 																</division>
 																<division alignSelf="auto" minWidth="100px" ratio="2" maxWidth="400px">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-3G_t-24025" datasource="SkuidLocal" model="News" url="https://picsum.photos/400/200?random=1">
+																		<skuid__image source="url" uniqueid="sk-3G_t-24025" model="News" url="https://picsum.photos/400/200?random=1">
 																			<styles>
 																				<spacing top="2"/>
 																			</styles>
@@ -61,7 +61,7 @@
 															<background/>
 														</skuid__grid>
 													</components>
-													<background datasource="SkuidLocal" source="url" size="auto" model="News" type="color" color="#fdeada"/>
+													<background source="url" size="auto" model="News" type="color" color="#fdeada"/>
 												</slide>
 												<slide slideName="Slide # 2">
 													<components>
@@ -69,7 +69,7 @@
 															<divisions>
 																<division alignSelf="auto" minWidth="100px" ratio="2" maxWidth="400px">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-3G_t-24027" datasource="SkuidLocal" model="News" url="https://picsum.photos/400/200?random=2">
+																		<skuid__image source="url" uniqueid="sk-3G_t-24027" model="News" url="https://picsum.photos/400/200?random=2">
 																			<styles>
 																				<spacing top="2"/>
 																			</styles>
@@ -93,7 +93,7 @@
 															<background/>
 														</skuid__grid>
 													</components>
-													<background type="color" datasource="SkuidLocal" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=2" color="#c6d9f0"/>
+													<background type="color" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=2" color="#c6d9f0"/>
 												</slide>
 												<slide slideName="Slide # 3">
 													<components>
@@ -111,7 +111,7 @@
 																</division>
 																<division alignSelf="auto" minWidth="100px" ratio="1" maxWidth="400px">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-3G_t-24029" datasource="SkuidLocal" model="News" url="https://picsum.photos/400/200?random=3">
+																		<skuid__image source="url" uniqueid="sk-3G_t-24029" model="News" url="https://picsum.photos/400/200?random=3">
 																			<styles>
 																				<spacing top="2"/>
 																			</styles>
@@ -125,7 +125,7 @@
 															<background/>
 														</skuid__grid>
 													</components>
-													<background type="color" datasource="SkuidLocal" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=3" color="#e5e0ec"/>
+													<background type="color" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=3" color="#e5e0ec"/>
 												</slide>
 											</slides>
 											<styles>
@@ -204,7 +204,7 @@
 																</division>
 																<division alignSelf="auto" minWidth="100px" ratio="1">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-29YV-86190" datasource="SkuidLocal" model="News" url="https://picsum.photos/400/200?random=1">
+																		<skuid__image source="url" uniqueid="sk-29YV-86190" model="News" url="https://picsum.photos/400/200?random=1">
 																			<styles>
 																				<spacing top="2"/>
 																			</styles>
@@ -218,7 +218,7 @@
 															<background/>
 														</skuid__grid>
 													</components>
-													<background datasource="SkuidLocal" source="url" size="auto" model="News" type="color" color="#fdeada"/>
+													<background source="url" size="auto" model="News" type="color" color="#fdeada"/>
 												</slide>
 												<slide slideName="Slide # 2">
 													<components>
@@ -236,7 +236,7 @@
 																</division>
 																<division alignSelf="auto" minWidth="100px" ratio="1">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-29Z2-94860" datasource="SkuidLocal" model="News" url="https://picsum.photos/400/200?random=2">
+																		<skuid__image source="url" uniqueid="sk-29Z2-94860" model="News" url="https://picsum.photos/400/200?random=2">
 																			<styles>
 																				<spacing top="2"/>
 																			</styles>
@@ -250,7 +250,7 @@
 															<background/>
 														</skuid__grid>
 													</components>
-													<background type="color" datasource="SkuidLocal" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=2" color="#c6d9f0"/>
+													<background type="color" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=2" color="#c6d9f0"/>
 												</slide>
 												<slide slideName="Slide # 3">
 													<components>
@@ -268,7 +268,7 @@
 																</division>
 																<division alignSelf="auto" minWidth="100px" ratio="1">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-29Z8-15205" datasource="SkuidLocal" model="News" url="https://picsum.photos/400/200?random=3">
+																		<skuid__image source="url" uniqueid="sk-29Z8-15205" model="News" url="https://picsum.photos/400/200?random=3">
 																			<styles>
 																				<spacing top="2"/>
 																			</styles>
@@ -282,7 +282,7 @@
 															<background/>
 														</skuid__grid>
 													</components>
-													<background type="color" datasource="SkuidLocal" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=3" color="#e5e0ec"/>
+													<background type="color" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random=3" color="#e5e0ec"/>
 												</slide>
 											</slides>
 										</skuid__carousel>
@@ -403,7 +403,7 @@
 											<styleVariantConditions/>
 										</skuid__grid>
 									</components>
-									<background datasource="SkuidLocal" source="url" size="cover" model="News" type="image" url="https://images.unsplash.com/photo-1551899714-406fb07fb6ae?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=2971&amp;q=80" position="center right"/>
+									<background source="url" size="cover" model="News" type="image" url="https://images.unsplash.com/photo-1551899714-406fb07fb6ae?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=2971&amp;q=80" position="center right"/>
 								</slide>
 								<slide slideName="Slide # 2">
 									<components>
@@ -475,7 +475,7 @@
 											<styleVariantConditions/>
 										</skuid__grid>
 									</components>
-									<background type="image" datasource="SkuidLocal" source="url" size="cover" model="News" url="https://images.unsplash.com/photo-1567941537651-70be5a2aafd2?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=3132&amp;q=80" color="#c6d9f0"/>
+									<background type="image" source="url" size="cover" model="News" url="https://images.unsplash.com/photo-1567941537651-70be5a2aafd2?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=3132&amp;q=80" color="#c6d9f0"/>
 								</slide>
 								<slide slideName="Slide # 3">
 									<components>
@@ -544,7 +544,7 @@
 											<styleVariantConditions/>
 										</skuid__grid>
 									</components>
-									<background type="image" datasource="SkuidLocal" source="url" size="cover" model="News" url="https://images.unsplash.com/photo-1642551426207-79eadf27cbd7?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=2874&amp;q=80" color="#e5e0ec"/>
+									<background type="image" source="url" size="cover" model="News" url="https://images.unsplash.com/photo-1642551426207-79eadf27cbd7?ixlib=rb-4.0.3&amp;ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&amp;auto=format&amp;fit=crop&amp;w=2874&amp;q=80" color="#e5e0ec"/>
 								</slide>
 							</slides>
 						</skuid__carousel>
@@ -580,7 +580,7 @@
 															<divisions>
 																<division alignSelf="auto" minWidth="200px" ratio="1">
 																	<components>
-																		<skuid__image source="url" uniqueid="sk-39H2-66554" datasource="SkuidLocal" model="News" url="https://picsum.photos/1000/300?random={{index}}&amp;grayscale" imageHeight="300px">
+																		<skuid__image source="url" uniqueid="sk-39H2-66554" model="News" url="https://picsum.photos/1000/300?random={{index}}&amp;grayscale" imageHeight="300px">
 																			<renderConditions logictype="and"/>
 																			<styleVariantConditions/>
 																			<styles>
@@ -599,7 +599,7 @@
 																					</styles>
 																				</skuid__text>
 																			</components>
-																			<background type="color" datasource="SkuidLocal" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random={{index}}&amp;grayscale" color="white"/>
+																			<background type="color" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random={{index}}&amp;grayscale" color="white"/>
 																			<styles>
 																				<spacing/>
 																			</styles>
@@ -607,14 +607,14 @@
 																	</components>
 																</division>
 															</divisions>
-															<background datasource="SkuidLocal" source="url" size="auto" model="News" color="transparent"/>
+															<background source="url" size="auto" model="News" color="transparent"/>
 															<styles>
 																<spacing/>
 															</styles>
 														</skuid__grid>
 													</components>
 													<renderConditions logictype="and"/>
-													<background datasource="SkuidLocal" source="url" size="auto" model="News"/>
+													<background source="url" size="auto" model="News"/>
 												</slide>
 											</slides>
 											<styles>
@@ -707,7 +707,7 @@
 																							<styles>
 																								<spacing top="3" bottom="3" left="3" right="3"/>
 																							</styles>
-																							<background type="color" datasource="SkuidLocal" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random={{index}}&amp;grayscale" color="rgba(255,255,255,0.75)"/>
+																							<background type="color" source="url" size="auto" model="News" url="https://picsum.photos/800/800?random={{index}}&amp;grayscale" color="rgba(255,255,255,0.75)"/>
 																						</skuid__wrapper>
 																					</components>
 																				</division>
@@ -751,12 +751,12 @@
 																			<styles>
 																				<spacing top="2" bottom="2"/>
 																			</styles>
-																			<background datasource="SkuidLocal" source="url" size="cover" model="News" url="https://picsum.photos/1000/300?random={{index}}&amp;grayscale" type="image"/>
+																			<background source="url" size="cover" model="News" url="https://picsum.photos/1000/300?random={{index}}&amp;grayscale" type="image"/>
 																			<renderConditions logictype="and"/>
 																			<styleVariantConditions/>
 																		</skuid__grid>
 																	</components>
-																	<background datasource="SkuidLocal" source="url" size="auto" model="News" color="transparent"/>
+																	<background source="url" size="auto" model="News" color="transparent"/>
 																</slide>
 															</slides>
 															<styles>
@@ -833,7 +833,7 @@
 																											<components/>
 																										</division>
 																									</divisions>
-																									<background datasource="SkuidLocal" source="url" size="cover" model="News"/>
+																									<background source="url" size="cover" model="News"/>
 																									<renderConditions logictype="and"/>
 																									<styleVariantConditions/>
 																									<styles>
@@ -841,7 +841,7 @@
 																									</styles>
 																								</skuid__grid>
 																							</components>
-																							<background datasource="SkuidLocal" source="url" size="contain" model="News" color="transparent" type="image" url="https://source.unsplash.com/collection/At5_35kBUtI/500x300/?sig={{previous}}"/>
+																							<background source="url" size="contain" model="News" color="transparent" type="image" url="https://source.unsplash.com/collection/At5_35kBUtI/500x300/?sig={{previous}}"/>
 																						</slide>
 																					</slides>
 																					<styles>
@@ -903,7 +903,7 @@
 																											<components/>
 																										</division>
 																									</divisions>
-																									<background datasource="SkuidLocal" source="url" size="cover" model="News"/>
+																									<background source="url" size="cover" model="News"/>
 																									<renderConditions logictype="and"/>
 																									<styleVariantConditions/>
 																									<styles>
@@ -911,7 +911,7 @@
 																									</styles>
 																								</skuid__grid>
 																							</components>
-																							<background datasource="SkuidLocal" source="url" size="contain" model="News" color="transparent" type="image" url="https://source.unsplash.com/collection/At5_35kBUtI/500x300/?sig={{next}}"/>
+																							<background source="url" size="contain" model="News" color="transparent" type="image" url="https://source.unsplash.com/collection/At5_35kBUtI/500x300/?sig={{next}}"/>
 																						</slide>
 																					</slides>
 																					<styles>
@@ -927,7 +927,7 @@
 																	</components>
 																</division>
 															</divisions>
-															<background datasource="SkuidLocal" source="url" size="cover" model="News"/>
+															<background source="url" size="cover" model="News"/>
 															<renderConditions logictype="and"/>
 															<styleVariantConditions/>
 															<styles>
@@ -935,7 +935,7 @@
 															</styles>
 														</skuid__grid>
 													</components>
-													<background datasource="SkuidLocal" source="url" size="cover" model="News" color="transparent" type="image" url="https://source.unsplash.com/collection/At5_35kBUtI/500x300/?sig={{index}}"/>
+													<background source="url" size="cover" model="News" color="transparent" type="image" url="https://source.unsplash.com/collection/At5_35kBUtI/500x300/?sig={{index}}"/>
 												</slide>
 											</slides>
 											<styles>
@@ -1061,7 +1061,7 @@
 																									</styles>
 																								</skuid__wrapper>
 																							</components>
-																							<background type="image" datasource="SkuidLocal" source="url" size="cover" model="News" url="https://picsum.photos/300/250?random={{index}}&amp;grayscale"/>
+																							<background type="image" source="url" size="cover" model="News" url="https://picsum.photos/300/250?random={{index}}&amp;grayscale"/>
 																						</slide>
 																					</slides>
 																					<renderConditions logictype="and"/>
@@ -1090,7 +1090,7 @@
 																									</styles>
 																								</skuid__wrapper>
 																							</components>
-																							<background type="image" datasource="SkuidLocal" source="url" size="cover" model="News" url="https://picsum.photos/300/200?random={{index}}&amp;grayscale"/>
+																							<background type="image" source="url" size="cover" model="News" url="https://picsum.photos/300/200?random={{index}}&amp;grayscale"/>
 																						</slide>
 																					</slides>
 																				</skuid__carousel>
@@ -1126,7 +1126,7 @@
 																					</styles>
 																				</skuid__wrapper>
 																			</components>
-																			<background type="image" datasource="SkuidLocal" source="url" size="cover" model="News" url="https://picsum.photos/500/300?random={{index}}&amp;grayscale"/>
+																			<background type="image" source="url" size="cover" model="News" url="https://picsum.photos/500/300?random={{index}}&amp;grayscale"/>
 																		</slide>
 																	</slides>
 																	<styles>


### PR DESCRIPTION
Removed "datasource=SkuidLocal" 31 times in the carousel page.  It was messing up the SFDC implementation of this sample page, and was unnecessary . 